### PR TITLE
 新闻摘要去掉错误显示的多个分号

### DIFF
--- a/resources/views/news/detail.blade.php
+++ b/resources/views/news/detail.blade.php
@@ -103,8 +103,11 @@
             position: absolute;
             top: 0; /* Set the top position of pinned element */
         }
-        .mdl-card__supporting-text{
-            padding: 16px 50px 16px 50px;
+
+        .mdl-card__supporting-text {
+            padding: 50px;
+            font-size: 1.1em !important;
+            line-height: 2em !important;
         }
 
     </style>
@@ -239,8 +242,7 @@
 //                    console.log();
 
                     for (var j = 0; j < imagesArray.length; j++) {
-                        content = content.replace("<br>[图片" + imagesArray[j][0] + "]<br>", "<div class='news-image'><img src='" + baseUrl + imagesArray[j][1] + "'/></div>");
-                        content = content.replace("[图片" + imagesArray[j][0] + "]", "<div class='news-image'><img src='" + baseUrl + imagesArray[j][1] + "'/></div>");
+                        content = content.replace("[图片" + imagesArray[j][0] + "]<br>", "<div class='news-image'><img src='" + baseUrl + imagesArray[j][1] + "'/></div>");
                     }
 
                     $(".mdl-card__supporting-text").html(content);

--- a/resources/views/news/index.blade.php
+++ b/resources/views/news/index.blade.php
@@ -226,7 +226,7 @@
                             <div class="news-content">
                                 <h6><b>{{mb_substr($news->title, 0, 30)}}</b></h6>
                                 <div class="content-body">
-                                    {{str_replace(array("<br>","<br","<b","&nbsp","&nbs","&nb"),'',mb_substr($news->content, 0, 40))}}
+                                    {{str_replace(array("<br>","<br","<b","&nbsp;", "&nbs"),'',mb_substr($news->content, 0, 40))}}
                                 </div>
                                 <small class="content-appendix">
                                     <span>责任编辑: admin</span><span>新闻来源:{{$news->quote}}</span><span>发布时间: {{mb_substr($news->created_at,0,10,'utf-8')}}</span>


### PR DESCRIPTION
新闻摘要去掉错误显示的多个分号；
去掉图片后面的换行，更新文字内容的排版；